### PR TITLE
Fix shelljs exec return object usage.

### DIFF
--- a/simctl.js
+++ b/simctl.js
@@ -43,11 +43,11 @@ exports = module.exports = {
         var obj = shell.exec(command, {silent: true});
 
         if (obj.code !== 0) {
-            obj.output = 'simctl was not found.\n';
-            obj.output += 'Check that you have Xcode 8.x installed:\n';
-            obj.output += '\txcodebuild --version\n';
-            obj.output += 'Check that you have Xcode 8.x selected:\n';
-            obj.output += '\txcode-select --print-path\n';
+            obj.stdout = 'simctl was not found.\n';
+            obj.stdout += 'Check that you have Xcode 8.x installed:\n';
+            obj.stdout += '\txcodebuild --version\n';
+            obj.stdout += 'Check that you have Xcode 8.x selected:\n';
+            obj.stdout += '\txcode-select --print-path\n';
         }
 
         return obj;
@@ -168,7 +168,7 @@ exports = module.exports = {
 
         if (obj.code === 0) {
             try {
-                obj.json = JSON.parse(obj.output);
+                obj.json = JSON.parse(obj.stdout);
             } catch (err) {
                 console.error(err.stack);
             }


### PR DESCRIPTION
Fixes #30, credit to @tzmartin for the fix.

In shelljs v0.6.0 (https://github.com/shelljs/shelljs/commit/8a7f7ce), the `output` property was changed to `stdout`.

When [simctl 2.0.1 was released](https://github.com/ios-control/simctl/releases/tag/v2.0.1), it [bumped shelljs from 0.2.6 to 0.8.5](https://github.com/ios-control/simctl/pull/26), which includes the above change. This broke things (see #30).

**breaking change**: This PR will require consumers of the `check_prerequisites` output object to change their usage (to be consistent with the output of shelljs), but it seems like a small break, given that it only changes where the error message is saved (and the underlying change came in 2.0.1 with the shelljs version update).

**Note:** Please release a new version in the 2.0.x chain once this is merged, so that all packages that depend on simctl as `"^2.0.0"` can get this new version automatically.